### PR TITLE
Fix: Update market cap for existing tickers

### DIFF
--- a/node-server/routers/ticker-router.js
+++ b/node-server/routers/ticker-router.js
@@ -233,12 +233,12 @@ function updateTickerData(responseData) {
     } else {
       // Add new ticker data
       latestTickerData.push(item);
+    }
 
-      // Add market cap data if available
-      if (item.s.endsWith(USDT_SUFFIX) && coinmarketcapMap.has(item.s)) {
-        const marketCapData = coinmarketcapMap.get(item.s);
-        item.market_cap = marketCapData.market_cap;
-      }
+    // Add market cap data if available
+    if (item.s.endsWith(USDT_SUFFIX) && coinmarketcapMap.has(item.s)) {
+      const marketCapData = coinmarketcapMap.get(item.s);
+      item.market_cap = marketCapData.market_cap;
     }
 
     // Add short-term changes if candlestick data is available

--- a/node-server/tests/calculations.test.js
+++ b/node-server/tests/calculations.test.js
@@ -256,3 +256,96 @@ describe("Backend Calculations", () => {
     });
   });
 });
+
+// New Test Suite for Market Cap Update
+describe("Market Cap Update", () => {
+  // Mock the coinmarketcap.json data
+  // Note: This path is relative to THIS test file, or ticker-router.js if using jest.mock in a setup file.
+  // For simplicity here, we assume jest.mock works directly with the path used in ticker-router.js
+  jest.mock("../coin-data/coinmarketcap.json", () => [
+    { symbol: "BTC", market_cap: 1200000000000 }, // New market cap for BTC
+    { symbol: "ETH", market_cap: 500000000000 },
+  ], { virtual: true }); // virtual: true might be needed if the file doesn't exist or to ensure it's always mocked
+
+  // It's challenging to directly test updateTickerData without exporting it from ticker-router.js.
+  // Also, latestTickerData is internal to ticker-router.js.
+  // This test outlines the logic but would require refactoring for a true unit test.
+  // An integration test approach would involve:
+  // 1. Setting up initial state (if possible, perhaps via a setup endpoint or by mocking initial data sources).
+  // 2. Triggering the WebSocket message that calls updateTickerData (hard with supertest alone for WebSockets).
+  // 3. Using an API endpoint (e.g., /api/ticker/24hr) to fetch the data and verify changes.
+
+  it("should conceptually update market_cap for existing tickers if updateTickerData were callable", () => {
+    // This is a conceptual test due to limitations mentioned above.
+
+    // Dynamically require ticker-router AFTER mocking coinmarketcap.json
+    // to ensure the mocked version is used. This is tricky.
+    // A better approach would be to ensure ticker-router.js can accept dependencies (like coinmarketcap data)
+    // or that `latestTickerData` can be manipulated for test setup.
+
+    // const { updateTickerData, latestTickerData } = require("../routers/ticker-router"); // This line won't work as they are not exported
+
+    // Mock initial latestTickerData (Conceptual: this array is not directly accessible)
+    const mockLatestTickerData = [
+      {
+        s: "BTCUSDT", // Existing ticker
+        c: "50000",   // Current price
+        P: "1.0",     // Price change percent
+        h: "51000",   // High
+        l: "49000",   // Low
+        v: "1000",    // Volume
+        market_cap: 1000000000000, // Initial market cap
+      },
+      {
+        s: "ETHUSDT", // Another existing ticker
+        c: "4000",
+        P: "2.0",
+        h: "4100",
+        l: "3900",
+        v: "5000",
+        market_cap: 400000000000, // Initial market cap
+      }
+    ];
+
+    // Mock responseData from WebSocket (this would be the input to updateTickerData)
+    const responseData = [
+      {
+        e: "24hrTicker", // Event type
+        E: 1672515782136, // Event time
+        s: "BTCUSDT",     // Symbol
+        p: "100.00",      // Price change
+        P: "0.10",        // Price change percent
+        w: "50500.00",    // Weighted average price
+        c: "51000.00",    // Last price
+        Q: "1.5",         // Last quantity
+        o: "50000.00",    // Open price
+        h: "52000.00",    // High price
+        l: "49000.00",    // Low price
+        v: "2000.00",     // Total traded base asset volume
+        q: "101000000.00",// Total traded quote asset volume
+        O: 1672429382136, // Statistics open time
+        C: 1672515782136, // Statistics close time
+        F: 1000,          // First trade ID
+        L: 2000,          // Last trade ID
+        n: 1001,          // Total number of trades
+      },
+      // Potentially other tickers in the response
+    ];
+
+    // --- Conceptual call to updateTickerData ---
+    // If updateTickerData were exported and latestTickerData modifiable:
+    // 1. Set latestTickerData = mockLatestTickerData
+    // 2. Call updateTickerData(responseData)
+    // 3. Assert changes in latestTickerData
+
+    // Example Assertion (Conceptual)
+    // const updatedBtcTicker = latestTickerData.find(item => item.s === "BTCUSDT");
+    // expect(updatedBtcTicker.market_cap).toBe(1200000000000); // New market cap from mocked coinmarketcap.json
+
+    // Since we cannot call updateTickerData directly or easily manipulate its state,
+    // we acknowledge this test is a placeholder for the logic.
+    // A true test would require refactoring or an integration testing approach.
+    expect(true).toBe(true); // Placeholder assertion
+    console.log("Market Cap Update test suite added. Note: Direct testing of updateTickerData is currently challenging without refactoring ticker-router.js.");
+  });
+});

--- a/node-server/tests/calculations.test.js
+++ b/node-server/tests/calculations.test.js
@@ -346,6 +346,6 @@ describe("Market Cap Update", () => {
     // we acknowledge this test is a placeholder for the logic.
     // A true test would require refactoring or an integration testing approach.
     expect(true).toBe(true); // Placeholder assertion
-    console.log("Market Cap Update test suite added. Note: Direct testing of updateTickerData is currently challenging without refactoring ticker-router.js.");
+    // Note: Direct testing of updateTickerData is currently challenging without refactoring ticker-router.js.
   });
 });


### PR DESCRIPTION
The `updateTickerData` function was previously only updating the market cap for newly added tickers. This change moves the market cap update logic to apply to all tickers, ensuring that market cap data is refreshed for existing tickers as well when WebSocket messages are processed.

A conceptual test case has been added to `calculations.test.js` outlining how this functionality should be tested. Direct unit testing of the `updateTickerData` function is currently challenging due to its lack of export and direct state manipulation. Future refactoring could improve testability.