### PR TITLE
feat: Sprint 4 — Transparency, Liquidity & Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,137 @@
 # Spikey Coins
 
-A cryptocurrency project - coming soon.
+An academic cryptocurrency-based commodities exchange for trading gold and silver futures with stablecoin settlement.
 
-## Development
+Built as a learning platform to explore exchange mechanics — order matching, margin trading, liquidation, funding rates, and price discovery — in a controlled, low-stakes environment.
+
+## Features
+
+- **Spot trading** — USDT/USDC exchange with a live order book
+- **Futures trading** — Gold (XAU-PERP) and Silver (XAG-PERP) perpetual contracts with up to 50x leverage
+- **Order matching engine** — price-time priority, partial fills, self-trade prevention
+- **Margin system** — initial/maintenance margin, mark pricing, and automatic liquidation
+- **Funding rates** — 8-hour intervals to keep futures prices anchored to spot
+- **Wallet system** — USDT/USDC deposits and withdrawals with balance tracking
+- **Liquidity provision** — one-click LP tool for placing two-sided limit orders
+- **Transparency dashboard** — public exchange stats: volume, fees, order book depth, recent trades
+- **Educational docs** — 17 pages covering commodities, futures, crypto trading, and technical architecture
+- **Live price feed** — Gold and silver index prices from metals.dev API
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Framework | Next.js 16.1.1, React 19, TypeScript |
+| Styling | Tailwind CSS 4, @tailwindcss/typography |
+| Auth | Firebase Auth (Google sign-in) + httpOnly session cookies |
+| Database | Vercel Postgres (Neon serverless) + Drizzle ORM |
+| Validation | Zod |
+| Deployment | Vercel |
+| Price Data | metals.dev API (gold/silver) |
+
+## Project Structure
+
+```
+app/
+├── (marketing)/          # Landing page, features, how it works
+├── (docs)/docs/          # 9 user guides + 8 technical docs
+├── (exchange)/exchange/  # Protected trading platform
+│   ├── dashboard/        # Portfolio overview
+│   ├── exchange/         # Spot trading (USDT ↔ USDC)
+│   ├── trade/gold/       # XAU-PERP futures
+│   ├── trade/silver/     # XAG-PERP futures
+│   ├── positions/        # Open positions
+│   ├── wallet/           # Balance & transactions
+│   ├── deposit/          # Deposit USDT/USDC
+│   ├── withdraw/         # Withdraw funds
+│   ├── transparency/     # Public exchange stats
+│   └── settings/         # User settings
+├── (auth)/               # Login, signup
+├── (legal)/              # Terms of service
+├── api/
+│   ├── auth/             # login, logout, session
+│   ├── wallet/           # deposit, withdraw
+│   └── trading/          # order, cancel, orderbook, trades, orders,
+│                         # positions, close, prices, funding, liquidate
+└── components/           # 23 shared components
+
+lib/
+├── auth/session.ts       # Server-side session verification
+├── db/
+│   ├── index.ts          # Lazy DB connection (Neon Pool)
+│   ├── schema.ts         # 6 Drizzle tables (users, wallets, transactions,
+│   │                     #   orders, trades, positions)
+│   └── queries/          # wallet.ts, trading.ts, transparency.ts
+├── firebase/             # client.ts (lazy init), admin.ts (lazy init)
+├── services/             # matching.ts, margin.ts, prices.ts, funding.ts
+└── trading/              # constants.ts, types.ts
+```
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 18+
+- A [Firebase](https://console.firebase.google.com/) project with Google sign-in enabled
+- A [Vercel Postgres](https://vercel.com/docs/storage/vercel-postgres) store (Neon)
+- A [metals.dev](https://metals.dev) API key (free tier, optional — falls back to hardcoded prices)
+
+### Setup
 
 ```bash
+# Clone and install
+git clone https://github.com/chandreshkkhatri/spikey-coins.git
+cd spikey-coins
 npm install
+
+# Configure environment
+cp .env.example .env.local
+# Fill in your values (see Environment Variables below)
+
+# Push database schema
+npx drizzle-kit push
+
+# Start development server
 npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) to view the app.
 
-## Tech Stack
+## Environment Variables
 
-- Next.js 16
-- React 19
-- Tailwind CSS 4
-- TypeScript
+Copy `.env.example` to `.env.local` and fill in your values. You can also run `vercel env pull .env.local` to pull from Vercel (then add `METALS_DEV_API_KEY` manually).
+
+| Variable | Service | Required |
+|----------|---------|----------|
+| `NEXT_PUBLIC_FIREBASE_API_KEY` | Firebase Client | Yes |
+| `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN` | Firebase Client | Yes |
+| `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | Firebase Client | Yes |
+| `FIREBASE_PROJECT_ID` | Firebase Admin | Yes |
+| `FIREBASE_CLIENT_EMAIL` | Firebase Admin | Yes |
+| `FIREBASE_PRIVATE_KEY` | Firebase Admin | Yes |
+| `POSTGRES_URL` | Vercel Postgres (pooled) | Yes |
+| `POSTGRES_URL_NON_POOLING` | Vercel Postgres (direct) | Yes |
+| `METALS_DEV_API_KEY` | metals.dev | No |
+
+## Scripts
+
+| Command | Description |
+|---------|------------|
+| `npm run dev` | Start development server |
+| `npm run build` | Production build |
+| `npm run start` | Start production server |
+| `npm run lint` | Run ESLint |
+| `npx drizzle-kit push` | Push schema changes to database |
+| `npx drizzle-kit studio` | Open Drizzle Studio (DB browser) |
+
+## Architecture
+
+The app uses **Next.js route groups** to separate concerns — each group has its own layout: marketing (navbar + footer), docs (sidebar + header), exchange (app sidebar + navbar), auth (centered minimal), and legal (centered prose). The exchange layout verifies the user session server-side and redirects unauthenticated users to `/login`.
+
+The **trading engine** runs synchronous order matching inside a database transaction. When an order is placed, it scans the opposite side of the book for price-compatible resting orders, executes fills at the resting order's price, and updates balances atomically. Futures use a mark price (70% index + 30% mid) for margin calculations, with a liquidation engine that force-closes positions below maintenance margin.
+
+Firebase and database connections use a **lazy initialization pattern** — they return safe no-ops during build time when environment variables aren't set, preventing build failures on Vercel.
+
+## Roadmap
+
+See [ROADMAP.md](ROADMAP.md) for sprint history and planned features.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,71 @@
+# Spikey Coins Roadmap
+
+An academic cryptocurrency-based commodities exchange for trading gold and silver futures with stablecoin settlement.
+
+## Completed Sprints
+
+### Sprint 0: Documentation + Placeholders
+- Project scaffolding with Next.js 16, React 19, Tailwind CSS 4
+- 5 route groups: (marketing), (docs), (exchange), (legal), (auth)
+- 14 documentation pages + 7 technical docs
+- Dark theme with gold (#F5A623) / silver (#C0C0C0) palette
+- ComingSoon component for unbuilt features
+
+### Sprint 1: Auth & User Accounts
+- Firebase Auth integration (Google sign-in)
+- PostgreSQL + Drizzle ORM for users/wallets tables
+- httpOnly session cookies (5-day expiry)
+- Protected exchange layout with session verification
+- Build-safe lazy initialization for Firebase/DB
+
+### Sprint 2: Wallet, Deposits & Withdrawals
+- Deposit flow: USDT/USDC, max $20 per deposit, only when balance < $5
+- Withdrawal flow: only when balance >= $10, $0.10 flat fee
+- Transactions table with signed amounts and balance snapshots
+- Server+client hybrid pattern for forms
+
+### Sprint 3: Trading Engine
+- 3 order books: USDT-USDC (spot), XAU-PERP (gold futures), XAG-PERP (silver futures)
+- Synchronous order matching with price-time priority and partial fills
+- Perpetual futures: up to 50x leverage, 2% initial margin, 1% maintenance margin
+- Mark price: 70% index (metals.dev API) + 30% order book mid
+- Funding rates: 8-hour intervals (00/08/16 UTC), clamped +/-1%
+- Liquidation engine for under-margined positions
+- Live gold/silver prices from metals.dev (30-min cache, 100 req/month free tier)
+
+### Sprint 4: Transparency + Liquidity (Current)
+- Transparency dashboard with public exchange statistics
+- One-click liquidity provision ("Provide Liquidity" feature)
+- Zero maker fees to incentivize limit order placement
+- Increased deposit limits ($5 -> $20 max, $1 -> $5 threshold)
+- Lowered spot minimum order size (0.01 -> 0.001)
+- Project roadmap (this file)
+
+### Infrastructure
+- Vercel deployment with Vercel Postgres (Neon serverless)
+- `@neondatabase/serverless` driver with WebSocket connections
+- 6 database tables with indexes for query performance
+
+## Backlog / Future Sprints
+
+### Sprint 5: System Market Maker (Planned)
+
+**Problem**: With few users in an academic setting, order books will be empty and no trades can happen. While Sprint 4's LP feature lets users manually provide liquidity, a system-level solution ensures baseline liquidity at all times.
+
+**Proposed Solution**: Market Maker Bot
+- System/house account that provides baseline liquidity
+- Places limit orders on both sides of each order book
+- Configurable spread around the index price (e.g., +/- 0.1%)
+- Configurable order sizes and refresh interval
+- Self-trade prevention already built into matching engine
+- Runs as a cron endpoint or background job
+
+### Sprint 6+: Potential Features
+- [ ] Real-time WebSocket price updates
+- [ ] Trade notifications (email or in-app)
+- [ ] Leaderboard / PnL rankings
+- [ ] Portfolio analytics and charts
+- [ ] Admin dashboard
+- [ ] Mobile-responsive improvements
+- [ ] API rate limiting
+- [ ] Automated testing suite

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,17 @@
 
 An academic cryptocurrency-based commodities exchange for trading gold and silver futures with stablecoin settlement.
 
+## Progress Summary
+
+| Sprint | Status | Routes | Key Deliverables |
+|--------|--------|--------|-----------------|
+| 0 — Documentation + Placeholders | Done | 31 | Next.js scaffold, 5 route groups, 17 doc pages, dark theme |
+| 1 — Auth & User Accounts | Done | 38 | Firebase Auth, sessions, users/wallets tables |
+| 2 — Wallet, Deposits & Withdrawals | Done | 40 | USDT/USDC deposits, withdrawals, transactions |
+| 3 — Trading Engine | Done | 47 | 3 order books, matching, futures, margin, liquidation |
+| 4 — Transparency + Liquidity | Done | 47 | Transparency dashboard, one-click LP, zero maker fees |
+| 5 — System Market Maker | Planned | — | Automated baseline liquidity bot |
+
 ## Completed Sprints
 
 ### Sprint 0: Documentation + Placeholders
@@ -33,7 +44,7 @@ An academic cryptocurrency-based commodities exchange for trading gold and silve
 - Liquidation engine for under-margined positions
 - Live gold/silver prices from metals.dev (30-min cache, 100 req/month free tier)
 
-### Sprint 4: Transparency + Liquidity (Current)
+### Sprint 4: Transparency + Liquidity
 - Transparency dashboard with public exchange statistics
 - One-click liquidity provision ("Provide Liquidity" feature)
 - Zero maker fees to incentivize limit order placement

--- a/app/(exchange)/exchange/deposit/page.tsx
+++ b/app/(exchange)/exchange/deposit/page.tsx
@@ -12,7 +12,7 @@ export default async function Deposit() {
     usdc?.balance ?? null
   );
 
-  const eligible = totalBalance < 1;
+  const eligible = totalBalance < 5;
 
   return (
     <div className="mx-auto max-w-lg">
@@ -56,7 +56,7 @@ export default async function Deposit() {
           </h3>
           <p className="text-sm text-zinc-400">
             Your total balance is ${totalBalance.toFixed(2)}. Deposits are only
-            available when your combined balance is below $1.00. Trade or
+            available when your combined balance is below $5.00. Trade or
             withdraw funds to become eligible again.
           </p>
         </div>

--- a/app/(exchange)/exchange/exchange/page.tsx
+++ b/app/(exchange)/exchange/exchange/page.tsx
@@ -4,7 +4,7 @@ import { getOrderBook, getRecentTrades, getUserOpenOrders } from "@/lib/db/queri
 import { PAIRS } from "@/lib/trading/constants";
 import OrderBook from "@/app/components/OrderBook";
 import TradeHistory from "@/app/components/TradeHistory";
-import OrderForm from "@/app/components/OrderForm";
+import TradingFormTabs from "@/app/components/TradingFormTabs";
 import OpenOrdersTable from "@/app/components/OpenOrdersTable";
 
 export default async function StablecoinExchange() {
@@ -54,7 +54,7 @@ export default async function StablecoinExchange() {
             </div>
           </div>
 
-          <OrderForm
+          <TradingFormTabs
             pair="USDT-USDC"
             pairType="spot"
             minQuantity={pairConfig.minQuantity}

--- a/app/(exchange)/exchange/trade/gold/page.tsx
+++ b/app/(exchange)/exchange/trade/gold/page.tsx
@@ -11,7 +11,7 @@ import { calculateUnrealizedPnl } from "@/lib/services/margin";
 import { PAIRS } from "@/lib/trading/constants";
 import OrderBook from "@/app/components/OrderBook";
 import TradeHistory from "@/app/components/TradeHistory";
-import OrderForm from "@/app/components/OrderForm";
+import TradingFormTabs from "@/app/components/TradingFormTabs";
 import OpenOrdersTable from "@/app/components/OpenOrdersTable";
 import PriceDisplay from "@/app/components/PriceDisplay";
 import PositionCard from "@/app/components/PositionCard";
@@ -102,7 +102,7 @@ export default async function GoldFutures() {
         </div>
 
         <div>
-          <OrderForm
+          <TradingFormTabs
             pair="XAU-PERP"
             pairType="futures"
             minQuantity={pairConfig.minQuantity}

--- a/app/(exchange)/exchange/trade/silver/page.tsx
+++ b/app/(exchange)/exchange/trade/silver/page.tsx
@@ -11,7 +11,7 @@ import { calculateUnrealizedPnl } from "@/lib/services/margin";
 import { PAIRS } from "@/lib/trading/constants";
 import OrderBook from "@/app/components/OrderBook";
 import TradeHistory from "@/app/components/TradeHistory";
-import OrderForm from "@/app/components/OrderForm";
+import TradingFormTabs from "@/app/components/TradingFormTabs";
 import OpenOrdersTable from "@/app/components/OpenOrdersTable";
 import PriceDisplay from "@/app/components/PriceDisplay";
 import PositionCard from "@/app/components/PositionCard";
@@ -98,7 +98,7 @@ export default async function SilverFutures() {
         </div>
 
         <div>
-          <OrderForm
+          <TradingFormTabs
             pair="XAG-PERP"
             pairType="futures"
             minQuantity={pairConfig.minQuantity}

--- a/app/(exchange)/exchange/transparency/page.tsx
+++ b/app/(exchange)/exchange/transparency/page.tsx
@@ -1,10 +1,320 @@
-import ComingSoon from "@/app/components/ComingSoon";
+import {
+  getTotalUserCount,
+  getTradingVolume,
+  getTotalFeeRevenue,
+  getWithdrawalFeeRevenue,
+  getOrderBookDepth,
+  getRecentTradesAnonymized,
+  getTradeCount,
+} from "@/lib/db/queries/transparency";
+import { getOpenInterest } from "@/lib/db/queries/trading";
+import { getIndexPrices, getMarkPrice } from "@/lib/services/prices";
 
-export default function Transparency() {
+export default async function Transparency() {
+  const now = new Date();
+  const twentyFourHoursAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+  const [
+    userCount,
+    tradeCount,
+    allTimeVolume,
+    tradingFees,
+    withdrawalFees,
+    volume24hSpot,
+    volume24hGold,
+    volume24hSilver,
+    oiGold,
+    oiSilver,
+    depthSpot,
+    depthGold,
+    depthSilver,
+    indexPrices,
+    goldMark,
+    silverMark,
+    recentTradesGold,
+    recentTradesSilver,
+    recentTradesSpot,
+  ] = await Promise.all([
+    getTotalUserCount(),
+    getTradeCount(),
+    getTradingVolume(),
+    getTotalFeeRevenue(),
+    getWithdrawalFeeRevenue(),
+    getTradingVolume("USDT-USDC", twentyFourHoursAgo),
+    getTradingVolume("XAU-PERP", twentyFourHoursAgo),
+    getTradingVolume("XAG-PERP", twentyFourHoursAgo),
+    getOpenInterest("XAU-PERP"),
+    getOpenInterest("XAG-PERP"),
+    getOrderBookDepth("USDT-USDC"),
+    getOrderBookDepth("XAU-PERP"),
+    getOrderBookDepth("XAG-PERP"),
+    getIndexPrices(),
+    getMarkPrice("XAU-PERP"),
+    getMarkPrice("XAG-PERP"),
+    getRecentTradesAnonymized("XAU-PERP", 10),
+    getRecentTradesAnonymized("XAG-PERP", 10),
+    getRecentTradesAnonymized("USDT-USDC", 10),
+  ]);
+
+  const totalFeeRevenue = (
+    parseFloat(tradingFees) + parseFloat(withdrawalFees)
+  ).toFixed(4);
+
+  const allRecentTrades = [
+    ...recentTradesGold,
+    ...recentTradesSilver,
+    ...recentTradesSpot,
+  ]
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+    .slice(0, 30);
+
+  function formatPrice(pair: string, price: string): string {
+    const p = parseFloat(price);
+    if (pair.includes("XAU")) return p.toFixed(2);
+    if (pair.includes("XAG")) return p.toFixed(3);
+    return p.toFixed(4);
+  }
+
   return (
-    <ComingSoon
-      title="Transparency Dashboard"
-      description="Public data about exchange activity. Total users, trading volume, fee revenue, exchange rates, and open interest."
-    />
+    <div className="mx-auto max-w-5xl">
+      <h1 className="mb-2 text-2xl font-bold text-white">
+        Transparency Dashboard
+      </h1>
+      <p className="mb-8 text-zinc-400">
+        Real-time exchange statistics and public data. All figures are from live
+        exchange data.
+      </p>
+
+      {/* Hero Stats */}
+      <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {[
+          { label: "Registered Users", value: userCount.toString(), accent: true },
+          { label: "Total Trades", value: tradeCount.toString(), accent: false },
+          {
+            label: "All-Time Volume",
+            value: `$${parseFloat(allTimeVolume).toFixed(2)}`,
+            accent: true,
+          },
+          {
+            label: "Fee Revenue",
+            value: `$${totalFeeRevenue}`,
+            accent: false,
+          },
+        ].map((stat) => (
+          <div
+            key={stat.label}
+            className="rounded-2xl border border-border bg-surface p-6 text-center"
+          >
+            <p className="text-xs text-zinc-500">{stat.label}</p>
+            <p
+              className={`mt-2 font-mono text-2xl font-bold ${stat.accent ? "text-gold" : "text-white"}`}
+            >
+              {stat.value}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Market Prices */}
+      <div className="mb-8">
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-[0.2em] text-gold">
+          Market Prices
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {[
+            {
+              name: "Gold (XAU)",
+              index: indexPrices.gold.toFixed(2),
+              mark: parseFloat(goldMark.markPrice).toFixed(2),
+              funding: goldMark.fundingRate,
+            },
+            {
+              name: "Silver (XAG)",
+              index: indexPrices.silver.toFixed(3),
+              mark: parseFloat(silverMark.markPrice).toFixed(3),
+              funding: silverMark.fundingRate,
+            },
+          ].map((m) => (
+            <div
+              key={m.name}
+              className="rounded-2xl border border-border bg-surface p-6"
+            >
+              <h3 className="mb-3 text-sm font-medium text-white">{m.name}</h3>
+              <dl className="space-y-2">
+                <div className="flex justify-between">
+                  <dt className="text-xs text-zinc-500">Index Price</dt>
+                  <dd className="font-mono text-sm text-white">${m.index}</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-xs text-zinc-500">Mark Price</dt>
+                  <dd className="font-mono text-sm text-white">${m.mark}</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-xs text-zinc-500">Funding Rate</dt>
+                  <dd
+                    className={`font-mono text-sm ${parseFloat(m.funding) >= 0 ? "text-green-400" : "text-red-400"}`}
+                  >
+                    {(parseFloat(m.funding) * 100).toFixed(4)}%
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Open Interest */}
+      <div className="mb-8">
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-[0.2em] text-gold">
+          Open Interest
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {[
+            { name: "XAU-PERP", data: oiGold },
+            { name: "XAG-PERP", data: oiSilver },
+          ].map((oi) => (
+            <div
+              key={oi.name}
+              className="rounded-2xl border border-border bg-surface p-6"
+            >
+              <h3 className="mb-3 text-sm font-medium text-white">{oi.name}</h3>
+              <dl className="space-y-2">
+                <div className="flex justify-between">
+                  <dt className="text-xs text-zinc-500">Long Contracts</dt>
+                  <dd className="font-mono text-sm text-green-400">
+                    {oi.data.longQuantity}
+                  </dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-xs text-zinc-500">Short Contracts</dt>
+                  <dd className="font-mono text-sm text-red-400">
+                    {oi.data.shortQuantity}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Order Book Depth */}
+      <div className="mb-8">
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-[0.2em] text-gold">
+          Order Book Depth
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {[
+            { name: "USDT-USDC", data: depthSpot },
+            { name: "XAU-PERP", data: depthGold },
+            { name: "XAG-PERP", data: depthSilver },
+          ].map((d) => (
+            <div
+              key={d.name}
+              className="rounded-2xl border border-border bg-surface p-6"
+            >
+              <h3 className="mb-3 text-sm font-medium text-white">{d.name}</h3>
+              <dl className="space-y-2">
+                <div className="flex justify-between">
+                  <dt className="text-xs text-zinc-500">Bid Volume</dt>
+                  <dd className="font-mono text-sm text-green-400">
+                    {parseFloat(d.data.bids.totalVolume).toFixed(2)}
+                  </dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-xs text-zinc-500">Ask Volume</dt>
+                  <dd className="font-mono text-sm text-red-400">
+                    {parseFloat(d.data.asks.totalVolume).toFixed(2)}
+                  </dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-xs text-zinc-500">Open Orders</dt>
+                  <dd className="font-mono text-sm text-white">
+                    {d.data.bids.orderCount + d.data.asks.orderCount}
+                  </dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt className="text-xs text-zinc-500">Spread</dt>
+                  <dd className="font-mono text-sm text-zinc-300">
+                    {d.data.spread ? `$${parseFloat(d.data.spread).toFixed(4)}` : "—"}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 24h Volume Breakdown */}
+      <div className="mb-8">
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-[0.2em] text-gold">
+          24h Volume
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {[
+            { name: "USDT-USDC", volume: volume24hSpot },
+            { name: "XAU-PERP", volume: volume24hGold },
+            { name: "XAG-PERP", volume: volume24hSilver },
+          ].map((v) => (
+            <div
+              key={v.name}
+              className="rounded-2xl border border-border bg-surface p-6 text-center"
+            >
+              <p className="text-xs text-zinc-500">{v.name}</p>
+              <p className="mt-2 font-mono text-lg font-semibold text-white">
+                ${parseFloat(v.volume).toFixed(2)}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Recent Trades (Anonymized) */}
+      <div>
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-[0.2em] text-gold">
+          Recent Trades
+        </h2>
+        {allRecentTrades.length === 0 ? (
+          <p className="text-sm text-zinc-500">No trades yet.</p>
+        ) : (
+          <div className="overflow-x-auto rounded-2xl border border-border bg-surface">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-left text-xs text-zinc-500">
+                  <th className="px-4 py-3">Pair</th>
+                  <th className="px-4 py-3">Price</th>
+                  <th className="px-4 py-3">Quantity</th>
+                  <th className="px-4 py-3">Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {allRecentTrades.map((t) => (
+                  <tr key={t.id} className="border-b border-border/50">
+                    <td className="px-4 py-2 text-white">{t.pair}</td>
+                    <td className="px-4 py-2 font-mono text-white">
+                      ${formatPrice(t.pair, t.price)}
+                    </td>
+                    <td className="px-4 py-2 font-mono text-zinc-300">
+                      {t.quantity}
+                    </td>
+                    <td className="px-4 py-2 text-zinc-500">
+                      {t.createdAt.toLocaleString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <p className="mt-8 text-center text-xs text-zinc-600">
+        Data updates on each page load. All figures are from live exchange data.
+      </p>
+    </div>
   );
 }

--- a/app/api/wallet/deposit/route.ts
+++ b/app/api/wallet/deposit/route.ts
@@ -9,8 +9,8 @@ const depositSchema = z.object({
   currency: z.enum(["USDT", "USDC"]),
   amount: z.string().refine((val) => {
     const num = parseFloat(val);
-    return !isNaN(num) && num > 0 && num <= 5;
-  }, "Amount must be between $0.01 and $5.00"),
+    return !isNaN(num) && num > 0 && num <= 20;
+  }, "Amount must be between $0.01 and $20.00"),
 });
 
 export async function POST(request: NextRequest) {
@@ -43,14 +43,14 @@ export async function POST(request: NextRequest) {
         throw new Error("Wallet not found");
       }
 
-      // Eligibility: total balance < $1
+      // Eligibility: total balance < $5
       const totalBalance =
         parseFloat(usdtWallet?.balance ?? "0") +
         parseFloat(usdcWallet?.balance ?? "0");
 
-      if (totalBalance >= 1) {
+      if (totalBalance >= 5) {
         throw new Error(
-          `Deposits are only allowed when your total balance is below $1.00. Your current total balance is $${totalBalance.toFixed(2)}.`
+          `Deposits are only allowed when your total balance is below $5.00. Your current total balance is $${totalBalance.toFixed(2)}.`
         );
       }
 

--- a/app/components/CallToAction.tsx
+++ b/app/components/CallToAction.tsx
@@ -8,23 +8,23 @@ export default function CallToAction() {
 
       <div className="relative z-10 mx-auto max-w-3xl px-6 text-center">
         <p className="mb-2 text-sm font-semibold uppercase tracking-[0.2em] text-gold">
-          Coming Soon
+          Start Now
         </p>
         <h2 className="mb-6 text-3xl font-bold text-white md:text-5xl">
-          Be First to Trade
+          Ready to Trade?
         </h2>
         <p className="mx-auto mb-10 max-w-xl text-lg leading-relaxed text-zinc-400">
-          Spikey Coins is launching soon. Join the early access list and be
-          among the first to trade gold and silver futures with cryptocurrency.
+          Sign up and start trading gold and silver futures with USDT and USDC.
+          Zero maker fees, up to 50x leverage, and full transparency.
         </p>
         <a
-          href="#"
+          href="/signup"
           className="animate-pulse-glow inline-block rounded-full bg-gold px-10 py-4 text-lg font-semibold text-black transition-colors hover:bg-gold-light"
         >
-          Join the Waitlist
+          Create Account
         </a>
         <p className="mt-6 text-xs text-zinc-600">
-          No commitment required. We will notify you at launch.
+          Free to sign up. Start trading in minutes.
         </p>
       </div>
     </section>

--- a/app/components/DepositForm.tsx
+++ b/app/components/DepositForm.tsx
@@ -13,7 +13,7 @@ export default function DepositForm() {
 
   const parsedAmount = parseFloat(amount);
   const isValidAmount =
-    !isNaN(parsedAmount) && parsedAmount > 0 && parsedAmount <= 5;
+    !isNaN(parsedAmount) && parsedAmount > 0 && parsedAmount <= 20;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -77,13 +77,13 @@ export default function DepositForm() {
 
         <div>
           <label className="mb-1.5 block text-sm text-zinc-400">
-            Amount (max $5.00)
+            Amount (max $20.00)
           </label>
           <input
             type="number"
             step="0.01"
             min="0.01"
-            max="5"
+            max="20"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
             placeholder="0.00"
@@ -112,7 +112,7 @@ export default function DepositForm() {
       </form>
 
       <p className="mt-4 text-xs text-zinc-500">
-        No platform fees. Maximum $5.00 per deposit.
+        No platform fees. Maximum $20.00 per deposit.
       </p>
     </div>
   );

--- a/app/components/Features.tsx
+++ b/app/components/Features.tsx
@@ -7,15 +7,15 @@ const features = [
   },
   {
     icon: "\u26D3\uFE0F",
-    title: "Blockchain Transparency",
+    title: "Full Transparency",
     description:
-      "Every trade is verifiable on-chain. Full audit trail with immutable record-keeping for complete peace of mind.",
+      "Public dashboard with live exchange stats — trading volume, fee revenue, order book depth, and recent trades. Nothing hidden.",
   },
   {
     icon: "\uD83D\uDEE1\uFE0F",
-    title: "Bank-Grade Security",
+    title: "Secure by Design",
     description:
-      "Multi-signature wallets, cold storage, and industry-leading security protocols protect your assets around the clock.",
+      "Server-side session verification, authenticated API routes, and secure credential handling protect your account and assets.",
   },
   {
     icon: "\uD83D\uDCCA",

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -24,10 +24,10 @@ export default function Hero() {
 
         <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
           <a
-            href="#early-access"
+            href="/signup"
             className="animate-pulse-glow rounded-full bg-gold px-8 py-3.5 text-base font-semibold text-black transition-colors hover:bg-gold-light"
           >
-            Get Early Access
+            Start Trading
           </a>
           <a
             href="#features"
@@ -38,7 +38,7 @@ export default function Hero() {
         </div>
 
         <div className="mt-12 flex items-center justify-center gap-6 text-xs font-medium uppercase tracking-wider text-zinc-500">
-          <span>Non-Custodial</span>
+          <span>Full Transparency</span>
           <span className="text-gold/50">{"\u25C6"}</span>
           <span>24/7 Trading</span>
           <span className="text-gold/50">{"\u25C6"}</span>

--- a/app/components/HowItWorks.tsx
+++ b/app/components/HowItWorks.tsx
@@ -1,27 +1,27 @@
 const steps = [
   {
     number: "01",
-    title: "Connect Your Wallet",
+    title: "Create Your Account",
     description:
-      "Link your cryptocurrency wallet to the Spikey Coins platform. We support all major wallets and chains.",
+      "Sign up with Google in seconds. No crypto wallet needed — just a Google account to get started.",
   },
   {
     number: "02",
     title: "Fund Your Account",
     description:
-      "Deposit crypto to your trading account. Multiple cryptocurrencies accepted as collateral for futures positions.",
+      "Deposit USDT or USDC to your trading wallet. Quick, simple, and ready to trade in minutes.",
   },
   {
     number: "03",
     title: "Choose Your Market",
     description:
-      "Select from gold or silver futures contracts with various expiration dates and leverage levels.",
+      "Trade USDT/USDC spot, or go long and short on gold and silver perpetual futures with up to 50x leverage.",
   },
   {
     number: "04",
     title: "Start Trading",
     description:
-      "Execute trades in real time with institutional-grade matching and blockchain-verified settlement.",
+      "Place market or limit orders with real-time matching. Provide liquidity and earn zero maker fees.",
   },
 ];
 

--- a/app/components/LPForm.tsx
+++ b/app/components/LPForm.tsx
@@ -1,0 +1,504 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface LPFormProps {
+  pair: string;
+  pairType: "spot" | "futures";
+  tickSize: string;
+  minQuantity: string;
+  usdtAvailable: number;
+  usdcAvailable: number;
+  currentPrice: string;
+  contractSize?: string;
+  maxLeverage?: number;
+}
+
+const SPREAD_PRESETS = [
+  { label: "Tight", value: 0.001, description: "±0.1%" },
+  { label: "Normal", value: 0.005, description: "±0.5%" },
+  { label: "Wide", value: 0.01, description: "±1.0%" },
+];
+
+const LEVEL_OPTIONS = [3, 5, 10];
+
+interface OrderPreview {
+  side: "buy" | "sell";
+  price: string;
+  quantity: string;
+  cost: number;
+}
+
+export default function LPForm({
+  pair,
+  pairType,
+  tickSize,
+  minQuantity,
+  usdtAvailable,
+  usdcAvailable,
+  currentPrice,
+  contractSize,
+  maxLeverage = 50,
+}: LPFormProps) {
+  const router = useRouter();
+  const [spread, setSpread] = useState(0.005);
+  const [levels, setLevels] = useState(3);
+  const [leverage, setLeverage] = useState(10);
+  const [collateral, setCollateral] = useState<"USDT" | "USDC">("USDT");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [progress, setProgress] = useState({ placed: 0, total: 0 });
+
+  // Spot: separate amounts for each side
+  const [sellAmount, setSellAmount] = useState("");
+  const [buyAmount, setBuyAmount] = useState("");
+  // Futures: single total amount
+  const [totalAmount, setTotalAmount] = useState("");
+
+  const centerPrice = parseFloat(currentPrice);
+  const tickSizeNum = parseFloat(tickSize);
+  const minQty = parseFloat(minQuantity);
+
+  function roundToTick(price: number): string {
+    const ticks = Math.round(price / tickSizeNum);
+    return (ticks * tickSizeNum).toFixed(
+      tickSize.includes(".") ? tickSize.split(".")[1].length : 0
+    );
+  }
+
+  function generateOrders(): OrderPreview[] {
+    if (isNaN(centerPrice) || centerPrice <= 0) return [];
+
+    const orders: OrderPreview[] = [];
+
+    if (pairType === "spot") {
+      const sellAmt = parseFloat(sellAmount);
+      const buyAmt = parseFloat(buyAmount);
+
+      // Sell side: selling USDT at prices above center
+      if (!isNaN(sellAmt) && sellAmt > 0) {
+        const perLevel = sellAmt / levels;
+        for (let i = 1; i <= levels; i++) {
+          const price = centerPrice * (1 + spread * i);
+          const qty = Math.max(perLevel, minQty);
+          orders.push({
+            side: "sell",
+            price: roundToTick(price),
+            quantity: qty.toFixed(
+              minQuantity.includes(".") ? minQuantity.split(".")[1].length : 0
+            ),
+            cost: qty,
+          });
+        }
+      }
+
+      // Buy side: buying USDT with USDC at prices below center
+      if (!isNaN(buyAmt) && buyAmt > 0) {
+        const perLevel = buyAmt / levels;
+        for (let i = 1; i <= levels; i++) {
+          const price = centerPrice * (1 - spread * i);
+          if (price <= 0) continue;
+          const qty = Math.max(perLevel / price, minQty);
+          orders.push({
+            side: "buy",
+            price: roundToTick(price),
+            quantity: qty.toFixed(
+              minQuantity.includes(".") ? minQuantity.split(".")[1].length : 0
+            ),
+            cost: qty * price,
+          });
+        }
+      }
+    } else {
+      // Futures: both sides from same collateral
+      const total = parseFloat(totalAmount);
+      if (isNaN(total) || total <= 0 || !contractSize) return [];
+
+      const cSize = parseFloat(contractSize);
+      const marginPerSide = total / 2;
+      const marginPerOrder = marginPerSide / levels;
+
+      for (let i = 1; i <= levels; i++) {
+        // Buy side (below center)
+        const buyPrice = centerPrice * (1 - spread * i);
+        if (buyPrice > 0) {
+          const notional = marginPerOrder * leverage;
+          const qty = Math.max(Math.floor(notional / (cSize * buyPrice)), 1);
+          const actualMargin = (qty * cSize * buyPrice) / leverage;
+          orders.push({
+            side: "buy",
+            price: roundToTick(buyPrice),
+            quantity: qty.toString(),
+            cost: actualMargin,
+          });
+        }
+
+        // Sell side (above center)
+        const sellPrice = centerPrice * (1 + spread * i);
+        const notional = marginPerOrder * leverage;
+        const qty = Math.max(Math.floor(notional / (cSize * sellPrice)), 1);
+        const actualMargin = (qty * cSize * sellPrice) / leverage;
+        orders.push({
+          side: "sell",
+          price: roundToTick(sellPrice),
+          quantity: qty.toString(),
+          cost: actualMargin,
+        });
+      }
+    }
+
+    return orders;
+  }
+
+  const preview = generateOrders();
+  const buyOrders = preview.filter((o) => o.side === "buy");
+  const sellOrders = preview.filter((o) => o.side === "sell");
+  const totalCostBuy = buyOrders.reduce((s, o) => s + o.cost, 0);
+  const totalCostSell = sellOrders.reduce((s, o) => s + o.cost, 0);
+
+  const canSubmit =
+    preview.length > 0 &&
+    !loading &&
+    (pairType === "spot"
+      ? totalCostSell <= usdtAvailable || totalCostBuy <= usdcAvailable
+      : parseFloat(totalAmount) > 0);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+    setLoading(true);
+    setProgress({ placed: 0, total: preview.length });
+
+    let placed = 0;
+    let failed = 0;
+
+    for (const order of preview) {
+      try {
+        const body: Record<string, unknown> = {
+          pair,
+          side: order.side,
+          type: "limit",
+          price: order.price,
+          quantity: order.quantity,
+        };
+
+        if (pairType === "futures") {
+          body.collateralCurrency = collateral;
+          body.leverage = leverage;
+        }
+
+        const res = await fetch("/api/trading/order", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+
+        if (!res.ok) {
+          const data = await res.json();
+          throw new Error(data.error || "Order failed");
+        }
+
+        placed++;
+        setProgress({ placed, total: preview.length });
+      } catch {
+        failed++;
+      }
+    }
+
+    setLoading(false);
+
+    if (placed > 0) {
+      setSuccess(
+        `Placed ${placed} of ${preview.length} orders${failed > 0 ? ` (${failed} failed)` : ""}`
+      );
+      setSellAmount("");
+      setBuyAmount("");
+      setTotalAmount("");
+      router.refresh();
+    } else {
+      setError("All orders failed. Check your balances and try again.");
+    }
+  }
+
+  const priceDecimals = tickSize.includes(".")
+    ? tickSize.split(".")[1].length
+    : 0;
+
+  return (
+    <div className="rounded-2xl border border-border bg-surface p-6">
+      <h2 className="mb-4 text-sm font-semibold uppercase tracking-[0.2em] text-gold">
+        Provide Liquidity
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Center Price */}
+        <div className="rounded-lg border border-border bg-black px-4 py-2.5 text-sm">
+          <span className="text-zinc-400">Center Price: </span>
+          <span className="font-mono text-white">
+            ${centerPrice.toFixed(priceDecimals)}
+          </span>
+        </div>
+
+        {/* Amount Inputs */}
+        {pairType === "spot" ? (
+          <>
+            <div>
+              <label className="mb-1.5 block text-sm text-zinc-400">
+                USDT to sell (above center)
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={sellAmount}
+                  onChange={(e) => setSellAmount(e.target.value)}
+                  placeholder="0.00"
+                  className="w-full rounded-lg border border-border bg-black px-4 py-2.5 font-mono text-white placeholder-zinc-600 outline-none transition-colors focus:border-gold/50"
+                />
+                <span className="text-xs text-zinc-500">
+                  avail: ${usdtAvailable.toFixed(2)}
+                </span>
+              </div>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm text-zinc-400">
+                USDC to buy with (below center)
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={buyAmount}
+                  onChange={(e) => setBuyAmount(e.target.value)}
+                  placeholder="0.00"
+                  className="w-full rounded-lg border border-border bg-black px-4 py-2.5 font-mono text-white placeholder-zinc-600 outline-none transition-colors focus:border-gold/50"
+                />
+                <span className="text-xs text-zinc-500">
+                  avail: ${usdcAvailable.toFixed(2)}
+                </span>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <div>
+              <label className="mb-1.5 block text-sm text-zinc-400">
+                Collateral
+              </label>
+              <div className="flex gap-2">
+                {(["USDT", "USDC"] as const).map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    onClick={() => setCollateral(c)}
+                    className={`rounded-lg border px-4 py-2 text-sm font-medium transition-colors ${
+                      collateral === c
+                        ? "border-gold bg-gold/10 text-gold"
+                        : "border-border text-zinc-400 hover:text-white"
+                    }`}
+                  >
+                    {c}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm text-zinc-400">
+                Total margin to allocate
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={totalAmount}
+                  onChange={(e) => setTotalAmount(e.target.value)}
+                  placeholder="0.00"
+                  className="w-full rounded-lg border border-border bg-black px-4 py-2.5 font-mono text-white placeholder-zinc-600 outline-none transition-colors focus:border-gold/50"
+                />
+                <span className="text-xs text-zinc-500">
+                  avail: $
+                  {(collateral === "USDT"
+                    ? usdtAvailable
+                    : usdcAvailable
+                  ).toFixed(2)}
+                </span>
+              </div>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm text-zinc-400">
+                Leverage: {leverage}x
+              </label>
+              <input
+                type="range"
+                min="1"
+                max={maxLeverage}
+                value={leverage}
+                onChange={(e) => setLeverage(parseInt(e.target.value))}
+                className="w-full accent-gold"
+              />
+              <div className="flex justify-between text-xs text-zinc-500">
+                <span>1x</span>
+                <span>{maxLeverage}x</span>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* Spread Selector */}
+        <div>
+          <label className="mb-1.5 block text-sm text-zinc-400">Spread</label>
+          <div className="flex gap-2">
+            {SPREAD_PRESETS.map((preset) => (
+              <button
+                key={preset.label}
+                type="button"
+                onClick={() => setSpread(preset.value)}
+                className={`flex-1 rounded-lg border px-3 py-2 text-center text-xs font-medium transition-colors ${
+                  spread === preset.value
+                    ? "border-gold bg-gold/10 text-gold"
+                    : "border-border text-zinc-400 hover:text-white"
+                }`}
+              >
+                <div>{preset.label}</div>
+                <div className="text-[10px] opacity-70">
+                  {preset.description}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Levels Selector */}
+        <div>
+          <label className="mb-1.5 block text-sm text-zinc-400">
+            Levels per side
+          </label>
+          <div className="flex gap-2">
+            {LEVEL_OPTIONS.map((l) => (
+              <button
+                key={l}
+                type="button"
+                onClick={() => setLevels(l)}
+                className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                  levels === l
+                    ? "border-gold bg-gold/10 text-gold"
+                    : "border-border text-zinc-400 hover:text-white"
+                }`}
+              >
+                {l}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Preview */}
+        {preview.length > 0 && (
+          <div className="rounded-lg border border-border bg-black p-4">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+              Preview — {preview.length} orders
+            </p>
+
+            {buyOrders.length > 0 && (
+              <div className="mb-2">
+                <p className="mb-1 text-xs text-green-400">
+                  Buy orders ({buyOrders.length})
+                </p>
+                {buyOrders.map((o, i) => (
+                  <div
+                    key={i}
+                    className="flex justify-between text-xs font-mono"
+                  >
+                    <span className="text-zinc-300">
+                      ${o.price} × {o.quantity}
+                      {pairType === "futures" ? " contracts" : ""}
+                    </span>
+                    <span className="text-zinc-500">
+                      {pairType === "spot"
+                        ? `$${o.cost.toFixed(2)} USDC`
+                        : `$${o.cost.toFixed(4)} margin`}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {sellOrders.length > 0 && (
+              <div className="mb-2">
+                <p className="mb-1 text-xs text-red-400">
+                  Sell orders ({sellOrders.length})
+                </p>
+                {sellOrders.map((o, i) => (
+                  <div
+                    key={i}
+                    className="flex justify-between text-xs font-mono"
+                  >
+                    <span className="text-zinc-300">
+                      ${o.price} × {o.quantity}
+                      {pairType === "futures" ? " contracts" : ""}
+                    </span>
+                    <span className="text-zinc-500">
+                      {pairType === "spot"
+                        ? `$${o.cost.toFixed(2)} USDT`
+                        : `$${o.cost.toFixed(4)} margin`}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className="border-t border-border pt-2 text-xs">
+              {pairType === "spot" ? (
+                <div className="flex justify-between text-zinc-400">
+                  <span>
+                    Total: ${totalCostSell.toFixed(2)} USDT + $
+                    {totalCostBuy.toFixed(2)} USDC
+                  </span>
+                </div>
+              ) : (
+                <div className="flex justify-between text-zinc-400">
+                  <span>
+                    Total margin: ${(totalCostBuy + totalCostSell).toFixed(4)}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Status Messages */}
+        {error && (
+          <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+            {error}
+          </div>
+        )}
+        {success && (
+          <div className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-3 text-sm text-green-400">
+            {success}
+          </div>
+        )}
+
+        {/* Submit */}
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="w-full rounded-lg bg-gold px-4 py-2.5 font-semibold text-black transition-opacity hover:opacity-90 disabled:opacity-50"
+        >
+          {loading
+            ? `Placing orders... (${progress.placed}/${progress.total})`
+            : `Place ${preview.length} Orders`}
+        </button>
+
+        <p className="text-xs text-zinc-500">
+          Limit orders earn 0% maker fees. Orders remain open until filled or
+          cancelled.
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/app/components/TradingFormTabs.tsx
+++ b/app/components/TradingFormTabs.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import OrderForm from "./OrderForm";
+import LPForm from "./LPForm";
+
+interface TradingFormTabsProps {
+  pair: string;
+  pairType: "spot" | "futures";
+  minQuantity: string;
+  tickSize: string;
+  usdtAvailable: number;
+  usdcAvailable: number;
+  currentPrice: string;
+  contractSize?: string;
+  maxLeverage?: number;
+  initialMarginRate?: string;
+}
+
+export default function TradingFormTabs(props: TradingFormTabsProps) {
+  const [tab, setTab] = useState<"trade" | "lp">("trade");
+
+  return (
+    <div>
+      <div className="mb-4 flex gap-2">
+        {(
+          [
+            { key: "trade", label: "Trade" },
+            { key: "lp", label: "Provide Liquidity" },
+          ] as const
+        ).map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={`rounded-lg border px-4 py-2 text-sm font-medium transition-colors ${
+              tab === key
+                ? "border-gold bg-gold/10 text-gold"
+                : "border-border text-zinc-400 hover:text-white"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "trade" ? (
+        <OrderForm {...props} />
+      ) : (
+        <LPForm {...props} />
+      )}
+    </div>
+  );
+}

--- a/lib/db/queries/transparency.ts
+++ b/lib/db/queries/transparency.ts
@@ -1,0 +1,129 @@
+import { db } from "@/lib/db";
+import { users, trades, transactions, orders } from "@/lib/db/schema";
+import { eq, and, sql, gte, desc } from "drizzle-orm";
+
+export async function getTotalUserCount(): Promise<number> {
+  const [result] = await db
+    .select({ count: sql<number>`COUNT(*)::int` })
+    .from(users);
+  return result.count;
+}
+
+export async function getTradingVolume(
+  pair?: string,
+  since?: Date
+): Promise<string> {
+  const conditions = [];
+  if (pair) conditions.push(eq(trades.pair, pair));
+  if (since) conditions.push(gte(trades.createdAt, since));
+
+  const [result] = await db
+    .select({
+      volume: sql<string>`COALESCE(SUM(${trades.price}::decimal * ${trades.quantity}::decimal), 0)::text`,
+    })
+    .from(trades)
+    .where(conditions.length > 0 ? and(...conditions) : undefined);
+
+  return result.volume;
+}
+
+export async function getTotalFeeRevenue(): Promise<string> {
+  const [result] = await db
+    .select({
+      totalFees: sql<string>`COALESCE(SUM(${trades.makerFee}::decimal + ${trades.takerFee}::decimal), 0)::text`,
+    })
+    .from(trades);
+  return result.totalFees;
+}
+
+export async function getWithdrawalFeeRevenue(): Promise<string> {
+  const [result] = await db
+    .select({
+      totalFees: sql<string>`COALESCE(SUM(ABS(${transactions.amount}::decimal)), 0)::text`,
+    })
+    .from(transactions)
+    .where(eq(transactions.type, "withdrawal_fee"));
+  return result.totalFees;
+}
+
+export async function getOrderBookDepth(pair: string) {
+  const [bidDepth] = await db
+    .select({
+      totalVolume: sql<string>`COALESCE(SUM(${orders.quantity}::decimal - ${orders.filledQuantity}::decimal), 0)::text`,
+      orderCount: sql<number>`COUNT(*)::int`,
+      bestPrice: sql<string>`MAX(${orders.price})`,
+    })
+    .from(orders)
+    .where(
+      and(
+        eq(orders.pair, pair),
+        eq(orders.side, "buy"),
+        sql`${orders.status} IN ('open', 'partial')`,
+        sql`${orders.price} IS NOT NULL`
+      )
+    );
+
+  const [askDepth] = await db
+    .select({
+      totalVolume: sql<string>`COALESCE(SUM(${orders.quantity}::decimal - ${orders.filledQuantity}::decimal), 0)::text`,
+      orderCount: sql<number>`COUNT(*)::int`,
+      bestPrice: sql<string>`MIN(${orders.price})`,
+    })
+    .from(orders)
+    .where(
+      and(
+        eq(orders.pair, pair),
+        eq(orders.side, "sell"),
+        sql`${orders.status} IN ('open', 'partial')`,
+        sql`${orders.price} IS NOT NULL`
+      )
+    );
+
+  const bestBid = bidDepth.bestPrice ? parseFloat(bidDepth.bestPrice) : null;
+  const bestAsk = askDepth.bestPrice ? parseFloat(askDepth.bestPrice) : null;
+  const spread =
+    bestBid !== null && bestAsk !== null
+      ? (bestAsk - bestBid).toFixed(8)
+      : null;
+
+  return {
+    bids: {
+      totalVolume: bidDepth.totalVolume,
+      orderCount: bidDepth.orderCount,
+      bestPrice: bidDepth.bestPrice,
+    },
+    asks: {
+      totalVolume: askDepth.totalVolume,
+      orderCount: askDepth.orderCount,
+      bestPrice: askDepth.bestPrice,
+    },
+    spread,
+  };
+}
+
+export async function getRecentTradesAnonymized(
+  pair: string,
+  limit: number = 20
+) {
+  return db
+    .select({
+      id: trades.id,
+      pair: trades.pair,
+      price: trades.price,
+      quantity: trades.quantity,
+      createdAt: trades.createdAt,
+    })
+    .from(trades)
+    .where(eq(trades.pair, pair))
+    .orderBy(desc(trades.createdAt))
+    .limit(limit);
+}
+
+export async function getTradeCount(pair?: string): Promise<number> {
+  const conditions = pair ? [eq(trades.pair, pair)] : [];
+  const [result] = await db
+    .select({ count: sql<number>`COUNT(*)::int` })
+    .from(trades)
+    .where(conditions.length > 0 ? and(...conditions) : undefined);
+  return result.count;
+}

--- a/lib/trading/constants.ts
+++ b/lib/trading/constants.ts
@@ -3,10 +3,10 @@ export const PAIRS = {
     base: "USDT",
     quote: "USDC",
     type: "spot" as const,
-    makerFeeRate: "0.0001", // 0.01%
+    makerFeeRate: "0", // 0% — incentivize liquidity provision
     takerFeeRate: "0.0003", // 0.03%
     tickSize: "0.0001",
-    minQuantity: "0.01",
+    minQuantity: "0.001",
   },
   "XAU-PERP": {
     base: "XAU",
@@ -14,7 +14,7 @@ export const PAIRS = {
     type: "futures" as const,
     contractSize: "0.001", // 0.001 troy oz per contract
     tickSize: "0.01",
-    makerFeeRate: "0.0002", // 0.02%
+    makerFeeRate: "0", // 0% — incentivize liquidity provision
     takerFeeRate: "0.0005", // 0.05%
     maxLeverage: 50,
     initialMarginRate: "0.02", // 2%
@@ -27,7 +27,7 @@ export const PAIRS = {
     type: "futures" as const,
     contractSize: "0.1", // 0.1 troy oz per contract
     tickSize: "0.001",
-    makerFeeRate: "0.0002", // 0.02%
+    makerFeeRate: "0", // 0% — incentivize liquidity provision
     takerFeeRate: "0.0005", // 0.05%
     maxLeverage: 50,
     initialMarginRate: "0.02",


### PR DESCRIPTION
## Summary
- **Transparency dashboard** — live exchange stats: registered users, trade count, all-time volume, fee revenue, market prices, open interest, order book depth, 24h volume, and recent anonymized trades
- **One-click liquidity provision** — new LP form on all 3 trading pages lets users place balanced two-sided limit orders around the current price with configurable spread (±0.1%/0.5%/1.0%) and depth levels (3/5/10)
- **Liquidity parameter tuning** — zero maker fees, increased deposit limits ($5→$20 max, $1→$5 threshold), lower spot minimum order size (0.01→0.001)
- **Project roadmap** — `ROADMAP.md` documenting Sprints 0–4 and backlog

## Changes
| File | Change |
|------|--------|
| `lib/trading/constants.ts` | Zero maker fees, lower spot min qty |
| `app/api/wallet/deposit/route.ts` | Max deposit $20, threshold $5 |
| `app/components/DepositForm.tsx` | Updated UI copy for new limits |
| `app/(exchange)/exchange/deposit/page.tsx` | Updated eligibility threshold |
| `app/components/LPForm.tsx` | **NEW** — one-click LP form (spot + futures) |
| `app/components/TradingFormTabs.tsx` | **NEW** — Trade / Provide Liquidity tab wrapper |
| 3 trading pages | Integrated TradingFormTabs |
| `lib/db/queries/transparency.ts` | **NEW** — 7 aggregate query functions |
| `app/(exchange)/exchange/transparency/page.tsx` | Full transparency dashboard |
| `ROADMAP.md` | **NEW** — project roadmap |

## Test plan
- [ ] Deposit page shows $20 max and allows deposit when balance < $5
- [ ] Trading pages show "Trade | Provide Liquidity" tab toggle
- [ ] LP form generates order preview and places orders via existing API
- [ ] Transparency dashboard renders all sections (works with zero data)
- [ ] `npm run build` passes cleanly (47 routes)